### PR TITLE
Update Docker environment from ROS Melodic to Noetic

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,27 @@
+name: Docker Build
+
+on:
+  push:
+    paths:
+      - 'docker/**'
+  pull_request:
+    paths:
+      - 'docker/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/
+          file: docker/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,38 +1,34 @@
 # Author: Tae Young Kim
 # email: tyoung96@yonsei.ac.kr
 
-FROM ros:melodic
+FROM ros:noetic-ros-base
 
-# Install PCL & Eigen & essential libraries
-RUN apt-get update && apt-get install -y cmake libeigen3-dev libpcl-dev \
-    ros-melodic-rviz ros-melodic-pcl-ros ros-melodic-eigen-conversions \
-    libatlas-base-dev libgoogle-glog-dev libsuitesparse-dev libglew-dev wget ros-melodic-image-transport-plugins
+# Install PCL & Eigen & Ceres & essential libraries
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake libeigen3-dev libpcl-dev \
+    ros-noetic-rviz ros-noetic-pcl-ros ros-noetic-eigen-conversions \
+    libatlas-base-dev libgoogle-glog-dev libsuitesparse-dev libceres-dev wget \
+    ros-noetic-jsk-recognition ros-noetic-jsk-common-msgs ros-noetic-jsk-rviz-plugins \
+    ros-noetic-jsk-recognition-msgs \
+    ros-noetic-image-transport-plugins \
+    python3-pip python3-tk python3-matplotlib git \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install jsk-visualization
-RUN apt-get update && apt-get install -y ros-melodic-jsk-recognition ros-melodic-jsk-common-msgs ros-melodic-jsk-rviz-plugins
-
-# Install matplotlib
-RUN apt-get update && apt-get install -y python-pip python-tk && pip install matplotlib
-
-# Install ceres-solver
+# Install Livox SDK
 WORKDIR /root/thirdParty
-RUN wget https://github.com/ceres-solver/ceres-solver/archive/refs/tags/2.0.0.tar.gz
-RUN tar zxf 2.0.0.tar.gz
-RUN cd ceres-solver-2.0.0
-RUN mkdir build && cd build
-RUN ls
-RUN cmake -DCMAKE_BUILD_TYPE=Release ./ceres-solver-2.0.0 && make -j2 && make install
+RUN git clone https://github.com/Livox-SDK/Livox-SDK.git \
+    && cd Livox-SDK/build && cmake .. && make -j$(nproc) && make install \
+    && rm -rf /root/thirdParty/Livox-SDK
 
 # Install livox driver
 WORKDIR /root/livox_ws/src
-RUN wget https://github.com/Livox-SDK/livox_ros_driver/archive/refs/tags/v2.6.0.tar.gz
-RUN tar zxf v2.6.0.tar.gz && rm -rf v2.6.0.tar.gz
+RUN wget -q https://github.com/Livox-SDK/livox_ros_driver/archive/refs/tags/v2.6.0.tar.gz \
+    && tar zxf v2.6.0.tar.gz && rm -f v2.6.0.tar.gz
 
-RUN /bin/bash -c '. /opt/ros/melodic/setup.bash; catkin_init_workspace'
+RUN /bin/bash -c '. /opt/ros/noetic/setup.bash; catkin_init_workspace'
 
 WORKDIR /root/livox_ws
-RUN /bin/bash -c 'source /opt/ros/melodic/setup.bash && catkin_make'
-RUN /bin/bash -c 'source /root/livox_ws/devel/setup.bash'
+RUN /bin/bash -c 'source /opt/ros/noetic/setup.bash && catkin_make'
 
 WORKDIR /root/catkin_ws/
 

--- a/docker/ros_entrypoint.sh
+++ b/docker/ros_entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Ros build
-source "/opt/ros/melodic/setup.bash"
+source "/opt/ros/noetic/setup.bash"
 source "/root/livox_ws/devel/setup.bash"
 
 
@@ -11,6 +11,7 @@ source "/root/livox_ws/devel/setup.bash"
 
 echo "================Gril-Calib Docker Env Ready================"
 
+mkdir -p /root/catkin_ws/src/Log /root/catkin_ws/src/result
 cd /root/catkin_ws
 
 exec "$@"


### PR DESCRIPTION
Hi @Taeyoung96,                                                                                                                                       
                                                                                                                                                        
  Based on our discussion in Issue #32, I've updated the **Dockerfile** for ROS Noetic and added **GitHub Actions CI** for Docker build verification.           
   
  ## Summary                                                                                                                                            
  This PR migrates the Docker environment from ROS Melodic to ROS Noetic. No source code changes are included.
                                                                                                                                                        
  - Base image: `ros:melodic` → `ros:noetic-ros-base`                                                                                                   
  - All `ros-melodic-*` packages → `ros-noetic-*`                                                                                                       
  - Replace Ceres source build with `libceres-dev` apt package                                                                                          
  - `python-pip` → `python3-pip`, `python3-matplotlib`                                     
  - Consolidate multiple `RUN apt-get update` into a single layer                                                                                       
  - Add Livox SDK build step (was missing, required by `livox_ros_driver`)
  - Add `ros-noetic-jsk-recognition-msgs` (patchworkpp dependency)                                                                                      
  - Remove unused `libglew-dev`                                                                                                                         
  - Create `Log/` and `result/` directories in entrypoint (fixes debug file open failure)
  - Add GitHub Actions CI for Docker build verification                                                                                                 
                                                                                           
  ## Changes                                                                                                                                            
  - `docker/Dockerfile` — Melodic → Noetic migration                                       
  - `docker/ros_entrypoint.sh` — source noetic setup, create debug directories
  - `.github/workflows/docker-build.yml` — Docker build CI with BuildKit caching                                                                        
   
  ## Verification                                                                                                                                       
  I've verified the following locally before opening this PR:                              
                                                                                                                                                        
  - [x] `docker build` succeeds
  - [x] `catkin_make` inside container                                                                                                                  
  - [x] Runtime test with rosbag data (calibration converges)                              
  - [x] GitHub Actions CI passes